### PR TITLE
Clarify the Aliexpress function

### DIFF
--- a/background.js
+++ b/background.js
@@ -131,7 +131,7 @@ browser.webRequest.onBeforeRequest.addListener(
 );
 
 
-function remove_searchparams(requestDetails) {
+function remove_alisearchparams(requestDetails) {
     var url = new URL(requestDetails.url)
     if (url.search.length > 0) {
         url.search = "";
@@ -140,7 +140,7 @@ function remove_searchparams(requestDetails) {
     }
 }
 browser.webRequest.onBeforeRequest.addListener(
-    remove_searchparams,
+    remove_alisearchparams,
     {
         urls: [
             "*://*.aliexpress.com/item/*.html*",

--- a/background.js
+++ b/background.js
@@ -19,15 +19,12 @@ function clean_utm(requestDetails) {
             /*console.info("Removing utm_* params from url: ",
                 requestDetails.url, "  and redirection to: ",
                 new_url.href);*/
-            return {
-                redirectUrl: new_url.href
-            }
+            return {redirectUrl: new_url.href};
         }
     }
 
 
-    return {
-    }
+    return {};
 }
 
 browser.webRequest.onBeforeRequest.addListener(


### PR DESCRIPTION
Minor tweak: Rename `remove_searchparams()` to `remove_alisearchparams()` in order to make the function name more descriptive.