### PR TITLE
Added Instagram, 4chan & Tumblr redirect cleanup

### DIFF
--- a/background.js
+++ b/background.js
@@ -171,6 +171,17 @@ const urls_to_param_mappers = [
   },
   {
     urls: ["*://steamcommunity.com/linkfilter/*"]
+  },
+  {
+    urls: ["*://l.instagram.com/*"],
+    param_name: 'u'
+  },
+  {
+    urls: ["*://t.umblr.com/*"],
+    param_name: 'z'
+  },
+  {
+    urls: ["*://sys.4chan.org/*"]
   }
 ];
 

--- a/test_urls.md
+++ b/test_urls.md
@@ -9,3 +9,9 @@ https://l.facebook.com/l.php?u=https%3A%2F%2Fwww.fsf.org%2Fcampaigns%2F&h=ATP1kf
 https://out.reddit.com/t3_5pq7qd?url=https%3A%2F%2Finternethealthreport.org%2Fv01%2F&token=AQAAZV6JWHBBnIcVjV1wvxVg5gKyCQQSdUhGIvuEUmdPZhxhm8kH&app_name=reddit.com
 
 https://steamcommunity.com/linkfilter/?url=https://getfedora.org/
+
+http://l.instagram.com/?u=http%3A%2F%2Fwww.espn.com%2F&e=ATPKY26Z5_uyeX4Ctrg1qpchVeS_WrWuUxIc0ZOOkw0D5eKJLKlZeUr8JTMqBKo
+
+http://t.umblr.com/redirect?z=http%3A%2F%2Fwww.syfy.com%2Fsyfywire%2Fastronomers-discover-a-new-type-of-star-blaps&t=OWVjZWQxNWMyYjgzMDhmMzQwODIzYzYzNWZiZGNmYzg3YzM4YmU5YyxjR0tuNWV0TQ%3D%3D&b=t%3ABczG7bf4maOuK2EGQxAofw&p=http%3A%2F%2Felimik.tumblr.com%2Fpost%2F164722605832&m=1
+
+https://sys.4chan.org/derefer?url=https%3A%2F%2Fbugzilla.mozilla.org%2Fshow_bug.cgi%3Fid%3D863246


### PR DESCRIPTION
Hey, I know you probably don't want to add an entry for every single website that creates redirects, but these 3 are pretty major sites so I think they'll be useful.