### PR TITLE
Improve Amazon link cleaning and add context menu item

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,5 +61,9 @@ $ rm -f ~/tmp/link_cleaner_1.5.zip
 $ zip -r -FS ~/tmp/link_cleaner_1.5.zip . -i manifest.* *.js
 ```
 
+# Credits
+
+German localization: [finke.media](https://www.finke.media)
+
 # License
 Released under the GPLv3 license

--- a/README.md
+++ b/README.md
@@ -12,35 +12,54 @@ You can now visit and bookmark clean links instead of the long,
 tracking-enabled ones!
 
 # Examples:
-- utm_* removal:  
-    http://meyerweb.com/eric/thoughts/2017/03/07/welcome-to-the-grid/?utm_source=frontendfocus&utm_medium=email  
-  is changed to:  
+- utm_* removal:
+    http://meyerweb.com/eric/thoughts/2017/03/07/welcome-to-the-grid/?utm_source=frontendfocus&utm_medium=email
+  is changed to:
     http://meyerweb.com/eric/thoughts/2017/03/07/welcome-to-the-grid/
-- amazon item url:  
-    https://www.amazon.com/AmazonBasics-Type-C-USB-Male-Cable/dp/B01GGKYQ02/ref=sr_1_1?s=amazonbasics&srs=10112675011&ie=UTF8&qid=1489067885&sr=8-1&keywords=usb-c  
-  is changed to:  
+- amazon item url:
+    https://www.amazon.com/AmazonBasics-Type-C-USB-Male-Cable/dp/B01GGKYQ02/ref=sr_1_1?s=amazonbasics&srs=10112675011&ie=UTF8&qid=1489067885&sr=8-1&keywords=usb-c
+  is changed to:
     https://www.amazon.com/AmazonBasics-Type-C-USB-Male-Cable/dp/B01GGKYQ02/
-- facebook redirect:  
-    https://l.facebook.com/l.php?u=https%3A%2F%2Fwww.fsf.org%2Fcampaigns%2F&h=ATP1kf98S0FxqErjoW8VmdSllIp4veuH2_m1jl69sEEeLzUXbkNXrVnzRMp65r5vf21LJGTgJwR2b66m97zYJoXx951n-pr4ruS1osMvT2c9ITsplpPU37RlSqJsSgba&s=1  
-  is changed to  
+- facebook redirect:
+    https://l.facebook.com/l.php?u=https%3A%2F%2Fwww.fsf.org%2Fcampaigns%2F&h=ATP1kf98S0FxqErjoW8VmdSllIp4veuH2_m1jl69sEEeLzUXbkNXrVnzRMp65r5vf21LJGTgJwR2b66m97zYJoXx951n-pr4ruS1osMvT2c9ITsplpPU37RlSqJsSgba&s=1
+  is changed to
     https://www.fsf.org/campaigns/
-- reddit redirect:  
-    https://out.reddit.com/t3_5pq7qd?url=https%3A%2F%2Finternethealthreport.org%2Fv01%2F&token=AQAAZV6JWHBBnIcVjV1wvxVg5gKyCQQSdUhGIvuEUmdPZhxhm8kH&app_name=reddit.com  
-  is changed to:  
+- reddit redirect:
+    https://out.reddit.com/t3_5pq7qd?url=https%3A%2F%2Finternethealthreport.org%2Fv01%2F&token=AQAAZV6JWHBBnIcVjV1wvxVg5gKyCQQSdUhGIvuEUmdPZhxhm8kH&app_name=reddit.com
+  is changed to:
     https://internethealthreport.org/v01/
-- steam redirect  
-    https://steamcommunity.com/linkfilter/?url=https://getfedora.org/  
-  is changed to:  
+- steam redirect
+    https://steamcommunity.com/linkfilter/?url=https://getfedora.org/
+  is changed to:
     https://getfedora.org/
+
+For a full list of test cases, have a look at the included `test_urls.html` file.
 
 # Comparison to other add-ons
 Unlike other legacy add-ons like CleanLinks, Link Cleaner doesn't inject
-JavaScript into pages to change links.
-Instead, it listens to main url requests and changes them (if needed to remove
-redirects or tracking.
+JavaScript into pages to change links.  Instead, it listens to main url requests
+and changes them (if needed to remove redirects or tracking.
 
 That means it's doing less unneeded work and consumes less resources
 (memory and CPU).
+
+# Notes
+
+Cleaning Amazon URLs will break any affiliation program. Just remember to use
+the usual "copy link location" shortcut that if you want to support the
+third-party affiliate program.
+
+# Test the extension locally
+
+Install Use the provided script `web-ext-run.sh` to launch Firefox with a
+dedicated profile, created at runtime. The add-ons is already installed and the
+browser will open on the test HTML page.
+
+# Build extension for publishing
+``` bash
+$ rm -f ~/tmp/link_cleaner_1.5.zip
+$ zip -r -FS ~/tmp/link_cleaner_1.5.zip . -i manifest.* *.js
+```
 
 # License
 Released under the GPLv3 license

--- a/_locales/de/messages.json
+++ b/_locales/de/messages.json
@@ -1,0 +1,16 @@
+{
+    "extensionName": {
+        "message": "Link cleaner",
+        "description": "Name of the extension."
+    },
+
+    "extensionDescription": {
+        "message": "Browser Add-on um URLs zu anonymisieren, bevor sie besucht werden.",
+        "description": "Description of the extension."
+    },
+
+    "menuItemCopyAndClean": {
+        "message": "Link-Addresse kopieren und anonymisieren",
+        "description": "Title of context menu item."
+    }
+}

--- a/_locales/de/messages.json
+++ b/_locales/de/messages.json
@@ -5,12 +5,12 @@
     },
 
     "extensionDescription": {
-        "message": "Browser Add-on um URLs zu anonymisieren, bevor sie besucht werden.",
+        "message": "Browser Add-on um URLs zu reinigen, bevor sie besucht werden.",
         "description": "Description of the extension."
     },
 
     "menuItemCopyAndClean": {
-        "message": "Link-Addresse kopieren und anonymisieren",
+        "message": "Link-Addresse kopieren und reinigen",
         "description": "Title of context menu item."
     }
 }

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1,0 +1,16 @@
+{
+    "extensionName": {
+        "message": "Link cleaner",
+        "description": "Name of the extension."
+    },
+
+    "extensionDescription": {
+        "message": "Browser extension to clean URLs that are about to be visited.",
+        "description": "Description of the extension."
+    },
+
+    "menuItemCopyAndClean": {
+        "message": "Copy and sanitize link",
+        "description": "Title of context menu item."
+    }
+}

--- a/_locales/it/messages.json
+++ b/_locales/it/messages.json
@@ -1,0 +1,16 @@
+{
+    "extensionName": {
+        "message": "Link cleaner",
+        "description": "Name of the extension."
+    },
+
+    "extensionDescription": {
+        "message": "Estensione per ripulire gli URL prima di visitarli.",
+        "description": "Description of the extension."
+    },
+
+    "menuItemCopyAndClean": {
+        "message": "Copia e pulisci link",
+        "description": "Title of context menu item."
+    }
+}

--- a/manifest.json
+++ b/manifest.json
@@ -16,5 +16,6 @@
         "contextMenus",
         "menus"
     ],
-    "version": "1.5"
+    "version": "1.5",
+    "default_locale": "en"
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,18 +1,20 @@
 {
-  "author": "Erwan Ameil",
-  "background": {
-    "scripts": [
-      "background.js"
-    ]
-  },
-  "description": "Clean URLs that are about to be visited: - removes utm_* parameters - on item pages of aliexpress and amazon, removes tracking parameters - skip redirect pages of facebook, steam and reddit (directly go to the url being redirected to, and never hit their outgoing redirect tracking)\nYou can now visit and bookmark clean links instead of the long, tracking-enabled ones!\n",
-  "homepage_url": "https://github.com/idlewan/link_cleaner",
-  "manifest_version": 2,
-  "name": "Link Cleaner",
-  "permissions": [
-    "<all_urls>",
-    "webRequest",
-    "webRequestBlocking"
-  ],
-  "version": "1.5"
+    "author": "Erwan Ameil",
+    "background": {
+        "scripts": [
+            "background.js"
+        ]
+    },
+    "description": "Clean URLs that are about to be visited: - removes utm_* parameters - on item pages of aliexpress and amazon, removes tracking parameters - skip redirect pages of facebook, steam and reddit (directly go to the url being redirected to, and never hit their outgoing redirect tracking)\nYou can now visit and bookmark clean links instead of the long, tracking-enabled ones!\n",
+    "homepage_url": "https://github.com/idlewan/link_cleaner",
+    "manifest_version": 2,
+    "name": "Link Cleaner",
+    "permissions": [
+        "<all_urls>",
+        "webRequest",
+        "webRequestBlocking",
+        "contextMenus",
+        "menus"
+    ],
+    "version": "1.5"
 }

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -22,3 +22,4 @@ permissions:
 - '<all_urls>'
 - webRequest
 - webRequestBlocking
+- contextMenus

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -23,3 +23,5 @@ permissions:
 - webRequest
 - webRequestBlocking
 - contextMenus
+
+default_locale: 'en'

--- a/test_urls.html
+++ b/test_urls.html
@@ -1,0 +1,53 @@
+<html>
+  <head>
+<title>Test page</title>
+</head>
+<body>
+<h1>Test page</h1>
+
+<a href="https://www.duckduckgo.com?utm_source=mrktg">UTM link test</a>
+<br/><br/>
+
+<a href="http://meyerweb.com/eric/thoughts/2017/03/07/welcome-to-the-grid/?utm_source=frontendfocus&utm_medium=email">meyerweb.com</a>
+<br /><br />
+
+<a href="https://www.amazon.co.uk/Crazepony-UK-Camera-Vacuum-Plastic-Crazepony/dp/B06XPCXCSH?SubscriptionId=AKIAILSHYYTFIVPWUY6Q&tag=duckduckgo-ffab-uk-21&linkCode=xm2&camp=2025&creative=165953&creativeASIN=B06XPCXCSH">amazon.com/*/dp/*</a>
+<br /><br />
+
+<a href="http://www.amazon.com/dp/B004Q0PT3I/ref=wl_it_dp_o_pC_nS_ttl?_encoding=UTF8&colid=1RVZE0UI0P44Q&coliid=I36IKWUBIN2XAC">amazon.com/dp/*</a>
+<br /><br />
+
+<a href="http://www.amazon.com/d/B004Q0PT3I/ref=wl_it_dp_o_pC_nS_ttl?_encoding=UTF8&colid=1RVZE0UI0P44Q&coliid=I">amazon.com/d/*</a>
+<br /><br />
+
+<a href="http://www.amazon.de/d/B004Q0PT3I/ref=wl_it_dp_o_pC_nS_ttl?_encoding=UTF8&colid=1RVZE0UI0P44Q&coliid=I">amazon.de/d/*</a>
+<br /><br />
+
+<a href="https://www.amazon.com/gp/aw/d/B0753K4CWG/ref=ods_gw_dg2_ha_mn_092018?pf_rd_p=3ecfdaf9-aa52-4068-a313-8ce3a863fa89&pf_rd_r=7MSHSTGR9GC0WDKHPJMR">amazon.com/gp/aw/d/*</a>
+<br /><br />
+
+<a href="http://www.amazon.com/gp/product/B003ZDJ42O/ref=oh_details_o00_s00_i00?ie=UTF8&psc=1">amazon.com/gp/product/*</a>
+<br /><br />
+
+<a href="https://l.facebook.com/l.php?u=https%3A%2F%2Fwww.fsf.org%2Fcampaigns%2F&h=ATP1kf98S0FxqErjoW8VmdSllIp4veuH2_m1jl69sEEeLzUXbkNXrVnzRMp65r5vf21LJGTgJwR2b66m97zYJoXx951n-pr4ruS1osMvT2c9ITsplpPU37RlSqJsSgba&s=1">fb</a>
+<br /><br />
+
+<a href="https://out.reddit.com/t3_5pq7qd?url=https%3A%2F%2Finternethealthreport.org%2Fv01%2F&token=AQAAZV6JWHBBnIcVjV1wvxVg5gKyCQQSdUhGIvuEUmdPZhxhm8kH&app_name=reddit.com">reddit</a>
+<br /><br />
+
+<a href="https://steamcommunity.com/linkfilter/?url=https://getfedora.org/">steam</a>
+<br /><br />
+
+
+paste link here:<br/>
+<textarea cols=80 rows=10></textarea>
+
+<a href="#"></a>
+<br /><br />
+
+<br/><br/><br/>
+<address>
+<a href="mailto:jman@valkyrie">jman</a>
+</address>
+</body>
+</html>

--- a/web-ext-run.sh
+++ b/web-ext-run.sh
@@ -1,0 +1,2 @@
+web-ext run --browser-console --target=firefox-desktop \
+        --start-url=file:///home/jman/Projects/link_cleaner/test_urls.html


### PR DESCRIPTION
This branch has two improvements:

* Improve Amazon links cleaning (remove SEO-friendly text)
* Add a menu context (solves #42 and #26)
* Enrich a little bit the documentation 

This is the base for my fork and I'm planning a couple more improvements (reason why I didnt do two different PRs), but if @idlewan or anyone is interested in improving this great extension, please let me know.

I'll leave this PR open for discussion.

thanks for evaluating!