### PR TITLE
feat(fbclid-removal): remove Facebook's `fbclid` parameter from URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ tracking-enabled ones!
     http://meyerweb.com/eric/thoughts/2017/03/07/welcome-to-the-grid/?utm_source=frontendfocus&utm_medium=email  
   is changed to:  
     http://meyerweb.com/eric/thoughts/2017/03/07/welcome-to-the-grid/
+- Facebook's `fbclid` removal:
+    http://meyerweb.com/eric/thoughts/2017/03/07/welcome-to-the-grid/?fbclid=abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ
+  is changed to:
+    http://meyerweb.com/eric/thoughts/2017/03/07/welcome-to-the-grid/
 - amazon item url:  
     https://www.amazon.com/AmazonBasics-Type-C-USB-Male-Cable/dp/B01GGKYQ02/ref=sr_1_1?s=amazonbasics&srs=10112675011&ie=UTF8&qid=1489067885&sr=8-1&keywords=usb-c  
   is changed to:  

--- a/background.js
+++ b/background.js
@@ -37,6 +37,42 @@ browser.webRequest.onBeforeRequest.addListener(
     ["blocking"]
 );
 
+// Filter out fbclid query parameter
+function clean_fbclid(requestDetails) {
+    var url = new URL(requestDetails.url)
+
+    if (url.search.length > 0) {
+        var params = url.searchParams;
+        var new_params = new URLSearchParams(params);
+        var needs_redirect = false;
+        for (let p of params.keys()) {
+            if (p.indexOf("fbclid") >= 0) {
+                needs_redirect = true;
+                new_params.delete(p);
+            }
+        }
+
+        if (needs_redirect) {
+            var new_url = new URL(url);
+            new_url.search = new_params.toString();
+
+            return {
+                redirectUrl: new_url.href
+            }
+        }
+    }
+
+    return { }
+}
+
+browser.webRequest.onBeforeRequest.addListener(
+    clean_fbclid,
+    {
+        urls: ["<all_urls>"],
+        types:["main_frame"]
+	  },
+    ["blocking"]
+);
 
 function clean_amazon(requestDetails) {
     var url = requestDetails.url;

--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,7 @@
       "background.js"
     ]
   },
-  "description": "Clean URLs that are about to be visited: - removes utm_* parameters - on item pages of aliexpress and amazon, removes tracking parameters - skip redirect pages of facebook, steam and reddit (directly go to the url being redirected to, and never hit their outgoing redirect tracking)\nYou can now visit and bookmark clean links instead of the long, tracking-enabled ones!\n",
+  "description": "Clean URLs that are about to be visited: - removes utm_* and fbclid parameters - on item pages of aliexpress and amazon, removes tracking parameters - skip redirect pages of facebook, steam and reddit (directly go to the url being redirected to, and never hit their outgoing redirect tracking)\nYou can now visit and bookmark clean links instead of the long, tracking-enabled ones!\n",
   "homepage_url": "https://github.com/idlewan/link_cleaner",
   "manifest_version": 2,
   "name": "Link Cleaner",

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -6,7 +6,7 @@ version: '1.5'
 
 description: >
   Clean URLs that are about to be visited:
-  - removes utm_* parameters
+  - removes utm_* and fbclid parameters
   - on item pages of aliexpress and amazon, removes tracking parameters
   - skip redirect pages of facebook, steam and reddit (directly go to the url
   being redirected to, and never hit their outgoing redirect tracking)

--- a/test_urls.md
+++ b/test_urls.md
@@ -1,5 +1,7 @@
 http://meyerweb.com/eric/thoughts/2017/03/07/welcome-to-the-grid/?utm_source=frontendfocus&utm_medium=email
 
+http://meyerweb.com/eric/thoughts/2017/03/07/welcome-to-the-grid/?fbclid=abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ
+
 https://www.amazon.com/AmazonBasics-Type-C-USB-Male-Cable/dp/B01GGKYQ02/ref=sr_1_1?s=amazonbasics&srs=10112675011&ie=UTF8&qid=1489067885&sr=8-1&keywords=usb-c
 
 https://www.amazon.co.uk/Crazepony-UK-Camera-Vacuum-Plastic-Crazepony/dp/B06XPCXCSH?SubscriptionId=AKIAILSHYYTFIVPWUY6Q&tag=duckduckgo-ffab-uk-21&linkCode=xm2&camp=2025&creative=165953&creativeASIN=B06XPCXCSH


### PR DESCRIPTION
Removes Facebook's `fbclid` parameter from URL.

Resolves Issue https://github.com/idlewan/link_cleaner/issues/44